### PR TITLE
C976 add sql server

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -8,11 +8,3 @@
     <h1 class="display-4">Welcome</h1>
     <p>Hello, world! The time on the server is @DateTime.Now</p>
 </div>
-
-<div class="text-center">
-    <h4>Sql Server Connection Result</h4>
-    @foreach(var result in Model.Result)
-    {
-        <p>@result</p>
-    }
-</div>

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -8,3 +8,11 @@
     <h1 class="display-4">Welcome</h1>
     <p>Hello, world! The time on the server is @DateTime.Now</p>
 </div>
+
+<div class="text-center">
+    <h4>Sql Server Connection Result</h4>
+    @foreach(var result in Model.Result)
+    {
+        <p>@result</p>
+    }
+</div>

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -1,11 +1,13 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Data.SqlClient;
 
 namespace aspnet_quickstart.Pages;
 
 public class IndexModel : PageModel
 {
     private readonly ILogger<IndexModel> _logger;
+    public List<string> Result = new List<string>();
 
     public IndexModel(ILogger<IndexModel> logger)
     {
@@ -14,6 +16,41 @@ public class IndexModel : PageModel
 
     public void OnGet()
     {
+        try
+        {
+            string connectionString = Environment.GetEnvironmentVariable("SQLSERVER_DSN");
+            // string connectionString = "Data Source=db;Initial Catalog=master;User ID=sa;Password=Password1234%^&*";
 
+            using (SqlConnection connection = new SqlConnection(connectionString))
+            {
+                Result.Add("Connecting to Sql Server...");
+
+                Console.WriteLine("\nQuery data example:");
+                Console.WriteLine("=========================================\n");
+
+                connection.Open();
+
+                String sql = "SELECT name, collation_name FROM sys.databases";
+
+                using (SqlCommand command = new SqlCommand(sql, connection))
+                {
+                    using (SqlDataReader reader = command.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            Result.Add(reader.GetString(0));
+                            Console.WriteLine(reader.GetString(0));
+                        }
+                    }
+                }
+            }
+        }
+        catch (SqlException e)
+        {
+            Console.WriteLine(e.ToString());
+            Result.Add($"Error occurred: {e.ToString()}");
+        }
+        Console.WriteLine("\nDone. Press enter.");
+        Console.ReadLine();
     }
 }

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -1,13 +1,11 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using System.Data.SqlClient;
 
 namespace aspnet_quickstart.Pages;
 
 public class IndexModel : PageModel
 {
     private readonly ILogger<IndexModel> _logger;
-    public List<string> Result = new List<string>();
 
     public IndexModel(ILogger<IndexModel> logger)
     {
@@ -16,41 +14,5 @@ public class IndexModel : PageModel
 
     public void OnGet()
     {
-        try
-        {
-            string connectionString = Environment.GetEnvironmentVariable("SQLSERVER_DSN");
-            // string connectionString = "Data Source=db;Initial Catalog=master;User ID=sa;Password=Password1234%^&*";
-
-            using (SqlConnection connection = new SqlConnection(connectionString))
-            {
-                Result.Add("Connecting to Sql Server...");
-
-                Console.WriteLine("\nQuery data example:");
-                Console.WriteLine("=========================================\n");
-
-                connection.Open();
-
-                String sql = "SELECT name, collation_name FROM sys.databases";
-
-                using (SqlCommand command = new SqlCommand(sql, connection))
-                {
-                    using (SqlDataReader reader = command.ExecuteReader())
-                    {
-                        while (reader.Read())
-                        {
-                            Result.Add(reader.GetString(0));
-                            Console.WriteLine(reader.GetString(0));
-                        }
-                    }
-                }
-            }
-        }
-        catch (SqlException e)
-        {
-            Console.WriteLine(e.ToString());
-            Result.Add($"Error occurred: {e.ToString()}");
-        }
-        Console.WriteLine("\nDone. Press enter.");
-        Console.ReadLine();
     }
 }

--- a/Pages/Privacy.cshtml
+++ b/Pages/Privacy.cshtml
@@ -6,3 +6,11 @@
 <h1>@ViewData["Title"]</h1>
 
 <p>Use this page to detail your site's privacy policy.</p>
+
+<div style="margin-top: 60px">
+    <h4>Sql Server Connection Result</h4>
+    @foreach(var result in Model.Result)
+    {
+        <p>@result</p>
+    }
+</div>

--- a/Pages/Privacy.cshtml.cs
+++ b/Pages/Privacy.cshtml.cs
@@ -19,7 +19,6 @@ public class PrivacyModel : PageModel
             try
             {
                 string connectionString = Environment.GetEnvironmentVariable("SQLSERVER_DSN");
-                // string connectionString = "Data Source=db;Initial Catalog=master;User ID=sa;Password=Password1234%^&*";
 
                 using (SqlConnection connection = new SqlConnection(connectionString))
                 {

--- a/Pages/Privacy.cshtml.cs
+++ b/Pages/Privacy.cshtml.cs
@@ -1,11 +1,13 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Data.SqlClient;
 
 namespace aspnet_quickstart.Pages;
 
 public class PrivacyModel : PageModel
 {
     private readonly ILogger<PrivacyModel> _logger;
+    public List<string> Result = new List<string>();
 
     public PrivacyModel(ILogger<PrivacyModel> logger)
     {
@@ -14,6 +16,42 @@ public class PrivacyModel : PageModel
 
     public void OnGet()
     {
+            try
+            {
+                string connectionString = Environment.GetEnvironmentVariable("SQLSERVER_DSN");
+                // string connectionString = "Data Source=db;Initial Catalog=master;User ID=sa;Password=Password1234%^&*";
+
+                using (SqlConnection connection = new SqlConnection(connectionString))
+                {
+                    Result.Add("Connecting to Sql Server...");
+
+                    Console.WriteLine("\nQuery data example:");
+                    Console.WriteLine("=========================================\n");
+
+                    connection.Open();
+
+                    String sql = "SELECT name, collation_name FROM sys.databases";
+
+                    using (SqlCommand command = new SqlCommand(sql, connection))
+                    {
+                        using (SqlDataReader reader = command.ExecuteReader())
+                        {
+                            while (reader.Read())
+                            {
+                                Result.Add(reader.GetString(0));
+                                Console.WriteLine(reader.GetString(0));
+                            }
+                        }
+                    }
+                }
+            }
+            catch (SqlException e)
+            {
+                Console.WriteLine(e.ToString());
+                Result.Add($"Error occurred: {e.ToString()}");
+            }
+            Console.WriteLine("\nDone. Press enter.");
+            Console.ReadLine();
     }
 }
 

--- a/aspnet-quickstart.csproj
+++ b/aspnet-quickstart.csproj
@@ -7,4 +7,8 @@
     <RootNamespace>aspnet_quickstart</RootNamespace>
   </PropertyGroup>
 
+<ItemGroup>
+    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+</ItemGroup>
+
 </Project>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,17 @@
 version: '3.8'
 
 services:
+  db:
+    image: mcr.microsoft.com/mssql/server
+    environment:
+      SA_PASSWORD: "Password1234%^&*"
+      ACCEPT_EULA: "Y"
   app:
     image: nullstone/dotnet:local
+    depends_on:
+      - db
+    environment:
+      SQLSERVER_DSN: "Data Source=db;Initial Catalog=master;User ID=sa;Password=Password1234%^&*"
     ports:
       - "5001:5001"
     volumes:


### PR DESCRIPTION
This PR updates this quickstart to spin up a sql server docker image locally. It connects to the sql server and outputs the dbs when you navigate to the `privacy` page.

Since we are reading the sql server connection string from an environment variable, this will also work once deployed to AWS via Nullstone. You just have to manually provide the value for the SQLSERVER_DSN environment variable.